### PR TITLE
update version number

### DIFF
--- a/cmd/carpenter/version.go
+++ b/cmd/carpenter/version.go
@@ -1,4 +1,4 @@
 package main
 
 const Name string = "carpenter"
-const Version string = "0.4.6"
+const Version string = "0.4.6k"


### PR DESCRIPTION
version numberの末尾に、knocknoteの「k」を付けておいた